### PR TITLE
Check if imgInputHelper exists before adding eventlistener.

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -55,7 +55,7 @@ const customFormSubmitHandler = (ev) => {
   printFiles(firstImgInput.files, container);
 };
 
-imgInputHelper.addEventListener("change", addImgHandler);
+imgInputHelper?.addEventListener("change", addImgHandler);
 
 document.querySelector(".custom__form")?.addEventListener("submit", customFormSubmitHandler);
 document.querySelector(".basic__form")?.addEventListener("submit", basicFormSubmitHandler);


### PR DESCRIPTION
This prevents an error while executing this script when the imgInputHelper element is not available.